### PR TITLE
アプリ情報取得サービスの実装 #5

### DIFF
--- a/src/services/app-service.test.ts
+++ b/src/services/app-service.test.ts
@@ -1,35 +1,37 @@
 /**
  * アプリ情報取得サービスのテスト
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { AppService } from './app-service';
-import { ApiClient } from '../utils/api-client';
+import { ApiClient, ApiClientError } from '../utils/api-client';
+import { AppSchema } from '../types';
 
 // ApiClientのモック
+const mockGetApps = vi.fn();
+const mockGetApp = vi.fn();
+const mockGetFormFields = vi.fn();
+const mockGetFormLayout = vi.fn();
+const mockGetViews = vi.fn();
+const mockGetAppCustomize = vi.fn();
+
 vi.mock('../utils/api-client', () => {
   return {
     ApiClient: vi.fn().mockImplementation(() => {
       return {
-        getApps: vi.fn().mockResolvedValue([
-          { appId: '1', name: 'App 1' },
-          { appId: '2', name: 'App 2' },
-        ]),
-        getApp: vi.fn().mockResolvedValue({
-          appId: '1',
-          name: 'App 1',
-          description: 'App description',
-        }),
-        getFormFields: vi.fn().mockResolvedValue({
-          properties: { field1: { type: 'SINGLE_LINE_TEXT' } }
-        }),
-        getFormLayout: vi.fn().mockResolvedValue({
-          layout: [{ type: 'ROW' }]
-        }),
-        getViews: vi.fn().mockResolvedValue({
-          views: { view1: { type: 'LIST' } }
-        }),
+        getApps: mockGetApps,
+        getApp: mockGetApp,
+        getFormFields: mockGetFormFields,
+        getFormLayout: mockGetFormLayout,
+        getViews: mockGetViews,
+        getAppCustomize: mockGetAppCustomize,
       };
     }),
+    ApiClientError: class ApiClientError extends Error {
+      constructor(message: string, statusCode?: number) {
+        super(message);
+        this.name = 'ApiClientError';
+      }
+    }
   };
 });
 
@@ -37,38 +39,347 @@ describe('AppService', () => {
   let appService: AppService;
 
   beforeEach(() => {
+    // モックの実装をセットアップ
+    mockGetApps.mockResolvedValue([
+      { appId: '1', name: 'App 1', description: 'Description 1', spaceId: '10' },
+      { appId: '2', name: 'App 2', description: 'Description 2', spaceId: '20' },
+    ]);
+    
+    mockGetApp.mockResolvedValue({
+      appId: '1',
+      name: 'App 1',
+      description: 'App description',
+      spaceId: '10',
+      threadId: '100',
+      creator: { code: 'user1', name: 'User 1' },
+      createdAt: '2025-01-01T00:00:00Z',
+      modifier: { code: 'user2', name: 'User 2' },
+      modifiedAt: '2025-01-02T00:00:00Z',
+    });
+    
+    mockGetFormFields.mockResolvedValue({
+      field1: { type: 'SINGLE_LINE_TEXT', code: 'field1', label: 'Field 1' },
+      field2: { type: 'NUMBER', code: 'field2', label: 'Field 2' },
+    });
+    
+    mockGetFormLayout.mockResolvedValue({
+      layout: [
+        { 
+          type: 'ROW',
+          code: 'row1',
+          fields: [
+            { type: 'SINGLE_LINE_TEXT', code: 'field1' }
+          ] 
+        }
+      ]
+    });
+    
+    mockGetViews.mockResolvedValue({
+      views: {
+        view1: { 
+          id: 'view1',
+          name: 'View 1',
+          type: 'LIST',
+          fields: ['field1']
+        }
+      }
+    });
+    
+    mockGetAppCustomize.mockResolvedValue({
+      desktop: {
+        js: [
+          { type: 'URL', url: 'https://example.com/script.js' }
+        ],
+        css: []
+      },
+      mobile: {
+        js: [],
+        css: []
+      }
+    });
+    
+    // テスト対象のサービスを初期化
     appService = new AppService();
   });
 
-  it('should get all apps', async () => {
-    const apps = await appService.getAllApps();
-    expect(apps).toHaveLength(2);
-    expect(apps[0].appId).toBe('1');
-    expect(apps[1].name).toBe('App 2');
+  afterEach(() => {
+    // モックをリセット
+    vi.clearAllMocks();
   });
 
-  it('should get app details', async () => {
-    const appDetails = await appService.getAppDetails(1);
-    expect(appDetails.appInfo).toBeDefined();
-    expect(appDetails.fields).toBeDefined();
-    expect(appDetails.layout).toBeDefined();
-    expect(appDetails.views).toBeDefined();
+  describe('getAllApps', () => {
+    it('アプリ一覧を取得できること', async () => {
+      const apps = await appService.getAllApps();
+      
+      expect(mockGetApps).toHaveBeenCalledWith(0, 100);
+      expect(apps).toHaveLength(2);
+      expect(apps[0].appId).toBe('1');
+      expect(apps[1].name).toBe('App 2');
+    });
+
+    it('ページネーションパラメータが正しく渡されること', async () => {
+      await appService.getAllApps(10, 50);
+      expect(mockGetApps).toHaveBeenCalledWith(10, 50);
+    });
+    
+    it('キャッシュが機能していること', async () => {
+      // 1回目の呼び出し
+      await appService.getAllApps();
+      expect(mockGetApps).toHaveBeenCalledTimes(1);
+      
+      // 2回目の呼び出し（キャッシュから取得されるはず）
+      await appService.getAllApps();
+      expect(mockGetApps).toHaveBeenCalledTimes(1); // APIは1回だけ呼ばれる
+      
+      // キャッシュをクリア
+      appService.clearCache();
+      
+      // 3回目の呼び出し（キャッシュがクリアされたのでAPIが呼ばれる）
+      await appService.getAllApps();
+      expect(mockGetApps).toHaveBeenCalledTimes(2);
+    });
   });
 
-  it('should get app form fields', async () => {
-    const fields = await appService.getAppFormFields(1);
-    expect(fields.properties).toBeDefined();
-    expect(fields.properties.field1.type).toBe('SINGLE_LINE_TEXT');
+  describe('searchApps', () => {
+    it('名前で検索できること', async () => {
+      const apps = await appService.searchApps({ name: 'App 1' });
+      
+      expect(apps).toHaveLength(1);
+      expect(apps[0].appId).toBe('1');
+    });
+    
+    it('スペースIDで検索できること', async () => {
+      const apps = await appService.searchApps({ spaceIds: ['20'] });
+      
+      expect(apps).toHaveLength(1);
+      expect(apps[0].appId).toBe('2');
+    });
+    
+    it('複数の条件で検索できること', async () => {
+      // App 1はspaceId='10'
+      const apps = await appService.searchApps({ 
+        name: 'App', 
+        spaceIds: ['10'] 
+      });
+      
+      expect(apps).toHaveLength(1);
+      expect(apps[0].appId).toBe('1');
+    });
   });
 
-  it('should get app form layout', async () => {
-    const layout = await appService.getAppFormLayout(1);
-    expect(layout.layout).toHaveLength(1);
+  describe('getAppDetails', () => {
+    it('アプリ詳細情報を取得できること', async () => {
+      const appDetails = await appService.getAppDetails(1);
+      
+      expect(appDetails.appInfo).toBeDefined();
+      expect(appDetails.fields).toBeDefined();
+      expect(appDetails.layout).toBeDefined();
+      expect(appDetails.views).toBeDefined();
+      expect(appDetails.customize).toBeDefined();
+      
+      expect(appDetails.appInfo.appId).toBe('1');
+      expect(Object.keys(appDetails.fields)).toContain('field1');
+      expect(appDetails.layout.layout[0].type).toBe('ROW');
+      expect(appDetails.views.views.view1.name).toBe('View 1');
+      expect(appDetails.customize.desktop.js[0].url).toBe('https://example.com/script.js');
+    });
+    
+    it('キャッシュが機能していること', async () => {
+      // 1回目の呼び出し
+      await appService.getAppDetails(1);
+      
+      // 2回目の呼び出し（キャッシュから取得されるはず）
+      await appService.getAppDetails(1);
+      
+      // すべてのAPIが1回ずつしか呼ばれないこと
+      expect(mockGetApp).toHaveBeenCalledTimes(1);
+      expect(mockGetFormFields).toHaveBeenCalledTimes(1);
+      expect(mockGetFormLayout).toHaveBeenCalledTimes(1);
+      expect(mockGetViews).toHaveBeenCalledTimes(1);
+      expect(mockGetAppCustomize).toHaveBeenCalledTimes(1);
+    });
   });
 
-  it('should get app views', async () => {
-    const views = await appService.getAppViews(1);
-    expect(views.views).toBeDefined();
-    expect(views.views.view1.type).toBe('LIST');
+  describe('getAppFormFields', () => {
+    it('フィールド情報を取得できること', async () => {
+      const fields = await appService.getAppFormFields(1);
+      
+      expect(mockGetFormFields).toHaveBeenCalledWith(1, undefined, undefined);
+      expect(fields).toHaveProperty('field1');
+      expect(fields).toHaveProperty('field2');
+      expect(fields.field1.type).toBe('SINGLE_LINE_TEXT');
+    });
+
+    it('オプションパラメータが正しく渡されること', async () => {
+      await appService.getAppFormFields(1, 'ja', true);
+      expect(mockGetFormFields).toHaveBeenCalledWith(1, 'ja', true);
+    });
+  });
+
+  describe('getAppFormLayout', () => {
+    it('レイアウト情報を取得できること', async () => {
+      const layout = await appService.getAppFormLayout(1);
+      
+      expect(mockGetFormLayout).toHaveBeenCalledWith(1, undefined);
+      expect(layout.layout).toHaveLength(1);
+      expect(layout.layout[0].type).toBe('ROW');
+    });
+
+    it('プレビューパラメータが正しく渡されること', async () => {
+      await appService.getAppFormLayout(1, true);
+      expect(mockGetFormLayout).toHaveBeenCalledWith(1, true);
+    });
+  });
+
+  describe('getAppViews', () => {
+    it('ビュー情報を取得できること', async () => {
+      const views = await appService.getAppViews(1);
+      
+      expect(mockGetViews).toHaveBeenCalledWith(1, undefined, undefined);
+      expect(views.views).toHaveProperty('view1');
+      expect(views.views.view1.name).toBe('View 1');
+    });
+
+    it('オプションパラメータが正しく渡されること', async () => {
+      await appService.getAppViews(1, 'ja', true);
+      expect(mockGetViews).toHaveBeenCalledWith(1, 'ja', true);
+    });
+  });
+  
+  describe('getAppCustomize', () => {
+    it('カスタマイズ情報を取得できること', async () => {
+      const customize = await appService.getAppCustomize(1);
+      
+      expect(mockGetAppCustomize).toHaveBeenCalledWith(1, undefined);
+      expect(customize.desktop.js[0].url).toBe('https://example.com/script.js');
+    });
+    
+    it('プレビューパラメータが正しく渡されること', async () => {
+      await appService.getAppCustomize(1, true);
+      expect(mockGetAppCustomize).toHaveBeenCalledWith(1, true);
+    });
+  });
+  
+  describe('exportAppSchema', () => {
+    it('アプリスキーマをエクスポートできること', async () => {
+      const schema = await appService.exportAppSchema(1);
+      
+      expect(schema.appId).toBe('1');
+      expect(schema.name).toBe('App 1');
+      expect(schema.fields).toBeDefined();
+      expect(schema.layout).toBeDefined();
+      expect(schema.views).toBeDefined();
+      expect(schema.customize).toBeDefined();
+      expect(schema.exportedAt).toBeDefined();
+      expect(schema.exportedBy).toEqual({
+        code: 'SYSTEM',
+        name: 'App Version Controller',
+      });
+    });
+  });
+  
+  describe('compareAppSchemas', () => {
+    it('2つのスキーマを比較して違いを検出できること', () => {
+      // テスト用のスキーマを作成
+      const schema1: AppSchema = {
+        appId: '1',
+        name: 'App 1 Old',
+        fields: {
+          field1: { type: 'SINGLE_LINE_TEXT', code: 'field1', label: 'Field 1' },
+          field2: { type: 'NUMBER', code: 'field2', label: 'Field 2' },
+        },
+        layout: {
+          layout: [{ type: 'ROW', code: 'row1', fields: [{ type: 'SINGLE_LINE_TEXT', code: 'field1' }] }]
+        },
+        views: {
+          views: {
+            view1: { id: 'view1', name: 'View 1', type: 'LIST', fields: ['field1'] }
+          }
+        },
+        exportedAt: '2025-01-01T00:00:00Z',
+        exportedBy: { code: 'user1', name: 'User 1' },
+      };
+      
+      const schema2: AppSchema = {
+        appId: '1',
+        name: 'App 1 New',
+        fields: {
+          field1: { type: 'SINGLE_LINE_TEXT', code: 'field1', label: 'Field 1 Updated' }, // 変更
+          field3: { type: 'DATE', code: 'field3', label: 'Field 3' }, // 追加
+          // field2 が削除
+        },
+        layout: {
+          layout: [{ type: 'ROW', code: 'row1', fields: [{ type: 'SINGLE_LINE_TEXT', code: 'field1' }] }]
+        },
+        views: {
+          views: {
+            view1: { id: 'view1', name: 'View 1 Updated', type: 'LIST', fields: ['field1'] }, // 変更
+            view2: { id: 'view2', name: 'View 2', type: 'CALENDAR', fields: ['field3'] }, // 追加
+          }
+        },
+        exportedAt: '2025-01-02T00:00:00Z',
+        exportedBy: { code: 'user2', name: 'User 2' },
+      };
+      
+      const result = appService.compareAppSchemas(schema1, schema2);
+      
+      // 検証
+      expect(result.appId1).toBe('1');
+      expect(result.appId2).toBe('1');
+      expect(result.differences).toHaveLength(5); // 5つの違いがあるはず
+      
+      // 統計情報の検証
+      expect(result.stats.fieldsAdded).toBe(1);   // field3 が追加
+      expect(result.stats.fieldsRemoved).toBe(1); // field2 が削除
+      expect(result.stats.fieldsModified).toBe(1); // field1 が変更
+      expect(result.stats.viewChanges).toBe(2);    // view1 が変更、view2 が追加
+      expect(result.stats.totalChanges).toBe(5);
+    });
+  });
+  
+  describe('キャッシュ制御', () => {
+    it('キャッシュを無効化できること', async () => {
+      // 最初の呼び出し
+      await appService.getAllApps();
+      expect(mockGetApps).toHaveBeenCalledTimes(1);
+      
+      // キャッシュを無効化
+      appService.setCacheEnabled(false);
+      
+      // 2回目の呼び出し（キャッシュが無効なのでAPIが呼ばれる）
+      await appService.getAllApps();
+      expect(mockGetApps).toHaveBeenCalledTimes(2);
+      
+      // キャッシュを再度有効化
+      appService.setCacheEnabled(true);
+      
+      // 3回目の呼び出し（キャッシュはリセットされているのでAPIが呼ばれる）
+      await appService.getAllApps();
+      expect(mockGetApps).toHaveBeenCalledTimes(3);
+      
+      // 4回目の呼び出し（キャッシュから取得されるはず）
+      await appService.getAllApps();
+      expect(mockGetApps).toHaveBeenCalledTimes(3);
+    });
+    
+    it('キャッシュをクリアできること', async () => {
+      // 最初の呼び出し
+      await appService.getAllApps();
+      expect(mockGetApps).toHaveBeenCalledTimes(1);
+      
+      // キャッシュをクリア
+      appService.clearCache();
+      
+      // 2回目の呼び出し（キャッシュがクリアされたのでAPIが呼ばれる）
+      await appService.getAllApps();
+      expect(mockGetApps).toHaveBeenCalledTimes(2);
+    });
+  });
+  
+  describe('エラーハンドリング', () => {
+    it('未実装のメソッドは適切なエラーをスローすること', async () => {
+      await expect(appService.getAppAcl(1)).rejects.toThrow('アクセス権情報取得機能は未実装です');
+      await expect(appService.getAppSettings(1)).rejects.toThrow('アプリ設定情報取得機能は未実装です');
+    });
   });
 });

--- a/src/services/app-service.ts
+++ b/src/services/app-service.ts
@@ -2,21 +2,57 @@
  * アプリ情報取得サービス
  * kintoneアプリの情報を取得するためのサービスクラス
  */
-import { ApiClient } from '../utils/api-client';
-import { AppInfo, AppDetail } from '../types';
+import { ApiClient, ApiClientError } from '../utils/api-client';
+import { 
+  AppInfo, 
+  AppDetail, 
+  AppFields, 
+  AppLayout, 
+  AppViews, 
+  AppCustomize, 
+  AppAcl, 
+  AppSettings, 
+  AppSearchCriteria, 
+  AppSchema,
+  SchemaComparisonResult,
+  VersionDiff
+} from '../types';
 import { sleep } from '../utils/helpers';
+import { MemoryCache } from '../utils/cache';
+import deepEqual from 'deep-equal';
+
+/**
+ * アプリ情報取得サービスインターフェース
+ */
+export interface IAppService {
+  getAllApps(offset?: number, limit?: number): Promise<AppInfo[]>;
+  searchApps(criteria: AppSearchCriteria): Promise<AppInfo[]>;
+  getAppDetails(appId: number): Promise<AppDetail>;
+  getAppFormFields(appId: number, lang?: string, preview?: boolean): Promise<AppFields>;
+  getAppFormLayout(appId: number, preview?: boolean): Promise<AppLayout>;
+  getAppViews(appId: number, lang?: string, preview?: boolean): Promise<AppViews>;
+  getAppCustomize(appId: number, preview?: boolean): Promise<AppCustomize>;
+  getAppAcl(appId: number): Promise<AppAcl>;
+  getAppSettings(appId: number): Promise<AppSettings>;
+  exportAppSchema(appId: number): Promise<AppSchema>;
+  compareAppSchemas(schema1: AppSchema, schema2: AppSchema): SchemaComparisonResult;
+  clearCache(): void;
+  setCacheEnabled(enabled: boolean): void;
+}
 
 /**
  * アプリ情報取得サービスクラス
  */
-export class AppService {
+export class AppService implements IAppService {
   private apiClient: ApiClient;
+  private cache: MemoryCache<any>;
   
   /**
    * コンストラクタ
    * @param apiClientOrBaseUrl ApiClientインスタンスまたはベースURL
+   * @param cacheEnabled キャッシュを有効にするかどうか
    */
-  constructor(apiClientOrBaseUrl?: ApiClient | string) {
+  constructor(apiClientOrBaseUrl?: ApiClient | string, cacheEnabled: boolean = true) {
     if (apiClientOrBaseUrl instanceof ApiClient) {
       // テスト用：既存のAPIクライアントを使用
       this.apiClient = apiClientOrBaseUrl;
@@ -24,14 +60,121 @@ export class AppService {
       // 新規APIクライアント作成
       this.apiClient = new ApiClient(apiClientOrBaseUrl);
     }
+    
+    // キャッシュを初期化
+    this.cache = new MemoryCache({ enabled: cacheEnabled });
   }
   
   /**
    * すべてのアプリ情報を取得する
+   * @param offset オフセット（ページネーション用）
+   * @param limit 取得件数（ページネーション用）
    * @returns アプリ一覧
    */
-  async getAllApps(): Promise<AppInfo[]> {
-    return await this.apiClient.getApps();
+  async getAllApps(offset: number = 0, limit: number = 100): Promise<AppInfo[]> {
+    const cacheKey = `getAllApps_${offset}_${limit}`;
+    const cachedResult = this.cache.get(cacheKey);
+    
+    if (cachedResult) {
+      return cachedResult;
+    }
+    
+    const apps = await this.apiClient.getApps(offset, limit);
+    this.cache.set(cacheKey, apps);
+    return apps;
+  }
+  
+  /**
+   * 条件に基づいてアプリを検索する
+   * @param criteria 検索条件
+   * @returns 検索結果
+   */
+  async searchApps(criteria: AppSearchCriteria): Promise<AppInfo[]> {
+    // オプションのデフォルト値
+    const { 
+      name, 
+      spaceIds,
+      limit = 100, 
+      offset = 0, 
+      creator,
+      modifiedAfter,
+      modifiedBefore
+    } = criteria;
+    
+    // 検索条件のハッシュをキャッシュキーとして使用
+    const cacheKey = `searchApps_${JSON.stringify(criteria)}`;
+    const cachedResult = this.cache.get(cacheKey);
+    
+    if (cachedResult) {
+      return cachedResult;
+    }
+    
+    try {
+      // すべてのアプリを取得
+      const allApps = await this.getAllApps(offset, limit);
+      
+      // クライアント側でフィルタリング
+      let filteredApps = allApps;
+      
+      // 名前でフィルタリング
+      if (name) {
+        filteredApps = filteredApps.filter(app => 
+          app.name.toLowerCase().includes(name.toLowerCase()) ||
+          (app.description && app.description.toLowerCase().includes(name.toLowerCase()))
+        );
+      }
+      
+      // スペースIDでフィルタリング
+      if (spaceIds && spaceIds.length > 0) {
+        filteredApps = filteredApps.filter(app => 
+          app.spaceId && spaceIds.includes(app.spaceId)
+        );
+      }
+      
+      // 作成者でフィルタリング（詳細情報が必要な場合は追加取得）
+      if (creator || modifiedAfter || modifiedBefore) {
+        // 詳細情報が必要なアプリのみ取得
+        const appsWithDetails = await Promise.all(
+          filteredApps.map(async app => {
+            try {
+              return await this.getApp(parseInt(app.appId));
+            } catch (error) {
+              console.warn(`アプリ詳細情報の取得に失敗: ${app.appId}`, error);
+              return app;
+            }
+          })
+        );
+        
+        filteredApps = appsWithDetails.filter(app => {
+          let match = true;
+          
+          // 作成者でフィルタリング
+          if (creator && app.creator) {
+            match = match && (
+              app.creator.code === creator || 
+              (app.creator.name && app.creator.name.includes(creator))
+            );
+          }
+          
+          // 更新日時でフィルタリング
+          if (modifiedAfter && app.modifiedAt) {
+            match = match && new Date(app.modifiedAt) >= new Date(modifiedAfter);
+          }
+          
+          if (modifiedBefore && app.modifiedAt) {
+            match = match && new Date(app.modifiedAt) <= new Date(modifiedBefore);
+          }
+          
+          return match;
+        });
+      }
+      
+      this.cache.set(cacheKey, filteredApps);
+      return filteredApps;
+    } catch (error) {
+      console.error('アプリ検索中にエラーが発生しました', error);
+      throw error;
+    }
   }
   
   /**
@@ -41,24 +184,42 @@ export class AppService {
    */
   async getAppDetails(appId: number): Promise<AppDetail> {
     try {
+      const cacheKey = `appDetails_${appId}`;
+      const cachedResult = this.cache.get(cacheKey);
+      
+      if (cachedResult) {
+        return cachedResult;
+      }
+      
       // APIリクエストの連続実行を避けるため少し待機
       await sleep(100);
       
       // 並列で各情報を取得
-      const [appInfo, fields, layout, views] = await Promise.all([
-        this.apiClient.getApp(appId),
-        this.apiClient.getFormFields(appId),
-        this.apiClient.getFormLayout(appId),
-        this.apiClient.getViews(appId),
+      const [appInfo, fields, layout, views, customize, acl, settings] = await Promise.all([
+        this.getApp(appId),
+        this.getAppFormFields(appId),
+        this.getAppFormLayout(appId),
+        this.getAppViews(appId),
+        this.getAppCustomize(appId).catch(e => undefined),
+        this.getAppAcl(appId).catch(e => undefined),
+        this.getAppSettings(appId).catch(e => undefined),
       ]);
       
       // 結果を統合
-      return {
+      const appDetail: AppDetail = {
         appInfo,
         fields,
         layout,
         views,
       };
+      
+      // オプションのデータがある場合は追加
+      if (customize) appDetail.customize = customize;
+      if (acl) appDetail.acl = acl;
+      if (settings) appDetail.settings = settings;
+      
+      this.cache.set(cacheKey, appDetail);
+      return appDetail;
     } catch (error) {
       console.error(`アプリ詳細情報(ID: ${appId})の取得中にエラーが発生しました`, error);
       throw error;
@@ -66,29 +227,332 @@ export class AppService {
   }
   
   /**
+   * アプリ情報を取得する
+   * @param appId アプリID
+   * @returns アプリ情報
+   */
+  async getApp(appId: number): Promise<AppInfo> {
+    const cacheKey = `app_${appId}`;
+    const cachedResult = this.cache.get(cacheKey);
+    
+    if (cachedResult) {
+      return cachedResult;
+    }
+    
+    const appInfo = await this.apiClient.getApp(appId);
+    this.cache.set(cacheKey, appInfo);
+    return appInfo;
+  }
+  
+  /**
    * アプリのフォームフィールド情報を取得する
    * @param appId アプリID
+   * @param lang 言語（オプション）
+   * @param preview プレビュー版を取得するかどうか（オプション）
    * @returns フォームフィールド情報
    */
-  async getAppFormFields(appId: number) {
-    return await this.apiClient.getFormFields(appId);
+  async getAppFormFields(appId: number, lang?: string, preview?: boolean): Promise<AppFields> {
+    const cacheKey = `formFields_${appId}_${lang || 'default'}_${preview ? 'preview' : 'live'}`;
+    const cachedResult = this.cache.get(cacheKey);
+    
+    if (cachedResult) {
+      return cachedResult;
+    }
+    
+    const fields = await this.apiClient.getFormFields(appId, lang, preview);
+    this.cache.set(cacheKey, fields);
+    return fields;
   }
   
   /**
    * アプリのフォームレイアウト情報を取得する
    * @param appId アプリID
+   * @param preview プレビュー版を取得するかどうか（オプション）
    * @returns フォームレイアウト情報
    */
-  async getAppFormLayout(appId: number) {
-    return await this.apiClient.getFormLayout(appId);
+  async getAppFormLayout(appId: number, preview?: boolean): Promise<AppLayout> {
+    const cacheKey = `formLayout_${appId}_${preview ? 'preview' : 'live'}`;
+    const cachedResult = this.cache.get(cacheKey);
+    
+    if (cachedResult) {
+      return cachedResult;
+    }
+    
+    const layout = await this.apiClient.getFormLayout(appId, preview);
+    this.cache.set(cacheKey, layout);
+    return layout;
   }
   
   /**
    * アプリのビュー情報を取得する
    * @param appId アプリID
+   * @param lang 言語（オプション）
+   * @param preview プレビュー版を取得するかどうか（オプション）
    * @returns ビュー情報
    */
-  async getAppViews(appId: number) {
-    return await this.apiClient.getViews(appId);
+  async getAppViews(appId: number, lang?: string, preview?: boolean): Promise<AppViews> {
+    const cacheKey = `views_${appId}_${lang || 'default'}_${preview ? 'preview' : 'live'}`;
+    const cachedResult = this.cache.get(cacheKey);
+    
+    if (cachedResult) {
+      return cachedResult;
+    }
+    
+    const views = await this.apiClient.getViews(appId, lang, preview);
+    this.cache.set(cacheKey, views);
+    return views;
+  }
+  
+  /**
+   * アプリのカスタマイズ情報（JS/CSSカスタマイズ）を取得する
+   * @param appId アプリID
+   * @param preview プレビュー版を取得するかどうか（オプション）
+   * @returns カスタマイズ情報
+   */
+  async getAppCustomize(appId: number, preview?: boolean): Promise<AppCustomize> {
+    const cacheKey = `customize_${appId}_${preview ? 'preview' : 'live'}`;
+    const cachedResult = this.cache.get(cacheKey);
+    
+    if (cachedResult) {
+      return cachedResult;
+    }
+    
+    const customize = await this.apiClient.getAppCustomize(appId, preview);
+    this.cache.set(cacheKey, customize);
+    return customize;
+  }
+  
+  /**
+   * アプリのアクセス権情報を取得する
+   * @param appId アプリID
+   * @returns アクセス権情報
+   */
+  async getAppAcl(appId: number): Promise<AppAcl> {
+    // この関数はモックや追加実装が必要
+    // 現在のAPI通信クライアントにはアクセス権取得のメソッドがないため例外をスロー
+    throw new ApiClientError('アクセス権情報取得機能は未実装です', 501);
+  }
+  
+  /**
+   * アプリの一般設定情報を取得する
+   * @param appId アプリID
+   * @returns 一般設定情報
+   */
+  async getAppSettings(appId: number): Promise<AppSettings> {
+    // この関数はモックや追加実装が必要
+    // 現在のAPI通信クライアントには一般設定取得のメソッドがないため例外をスロー
+    throw new ApiClientError('アプリ設定情報取得機能は未実装です', 501);
+  }
+  
+  /**
+   * アプリスキーマをエクスポートする
+   * @param appId アプリID
+   * @returns アプリスキーマ
+   */
+  async exportAppSchema(appId: number): Promise<AppSchema> {
+    try {
+      // アプリ詳細情報を取得
+      const appDetail = await this.getAppDetails(appId);
+      
+      // アプリスキーマを構築
+      const schema: AppSchema = {
+        appId: appDetail.appInfo.appId,
+        name: appDetail.appInfo.name,
+        fields: appDetail.fields,
+        layout: appDetail.layout,
+        views: appDetail.views,
+        // 取得できる場合は追加設定も含める
+        customize: appDetail.customize,
+        acl: appDetail.acl,
+        settings: appDetail.settings,
+        // エクスポートメタデータ
+        exportedAt: new Date().toISOString(),
+        exportedBy: {
+          code: 'SYSTEM',
+          name: 'App Version Controller',
+        },
+      };
+      
+      return schema;
+    } catch (error) {
+      console.error(`アプリスキーマのエクスポート中にエラーが発生しました(ID: ${appId})`, error);
+      throw error;
+    }
+  }
+  
+  /**
+   * 2つのアプリスキーマを比較する
+   * @param schema1 比較元のスキーマ
+   * @param schema2 比較先のスキーマ
+   * @returns 比較結果
+   */
+  compareAppSchemas(schema1: AppSchema, schema2: AppSchema): SchemaComparisonResult {
+    const differences: VersionDiff[] = [];
+    
+    // フィールドの比較
+    const allFieldCodes = new Set([
+      ...Object.keys(schema1.fields || {}),
+      ...Object.keys(schema2.fields || {})
+    ]);
+    
+    let fieldsAdded = 0;
+    let fieldsRemoved = 0;
+    let fieldsModified = 0;
+    
+    allFieldCodes.forEach(fieldCode => {
+      const field1 = schema1.fields?.[fieldCode];
+      const field2 = schema2.fields?.[fieldCode];
+      
+      if (!field1) {
+        // フィールドが追加された
+        differences.push({
+          path: `fields.${fieldCode}`,
+          oldValue: null,
+          newValue: field2,
+          changeType: 'added'
+        });
+        fieldsAdded++;
+      } else if (!field2) {
+        // フィールドが削除された
+        differences.push({
+          path: `fields.${fieldCode}`,
+          oldValue: field1,
+          newValue: null,
+          changeType: 'removed'
+        });
+        fieldsRemoved++;
+      } else if (!deepEqual(field1, field2)) {
+        // フィールドが変更された
+        differences.push({
+          path: `fields.${fieldCode}`,
+          oldValue: field1,
+          newValue: field2,
+          changeType: 'modified'
+        });
+        fieldsModified++;
+      }
+    });
+    
+    // レイアウトの比較（簡易比較）
+    const layoutChanged = !deepEqual(schema1.layout, schema2.layout);
+    const layoutChanges = layoutChanged ? 1 : 0;
+    
+    if (layoutChanged) {
+      differences.push({
+        path: 'layout',
+        oldValue: schema1.layout,
+        newValue: schema2.layout,
+        changeType: 'modified'
+      });
+    }
+    
+    // ビューの比較
+    const allViewIds = new Set([
+      ...Object.keys(schema1.views?.views || {}),
+      ...Object.keys(schema2.views?.views || {})
+    ]);
+    
+    let viewChanges = 0;
+    
+    allViewIds.forEach(viewId => {
+      const view1 = schema1.views?.views?.[viewId];
+      const view2 = schema2.views?.views?.[viewId];
+      
+      if (!view1) {
+        // ビューが追加された
+        differences.push({
+          path: `views.${viewId}`,
+          oldValue: null,
+          newValue: view2,
+          changeType: 'added'
+        });
+        viewChanges++;
+      } else if (!view2) {
+        // ビューが削除された
+        differences.push({
+          path: `views.${viewId}`,
+          oldValue: view1,
+          newValue: null,
+          changeType: 'removed'
+        });
+        viewChanges++;
+      } else if (!deepEqual(view1, view2)) {
+        // ビューが変更された
+        differences.push({
+          path: `views.${viewId}`,
+          oldValue: view1,
+          newValue: view2,
+          changeType: 'modified'
+        });
+        viewChanges++;
+      }
+    });
+    
+    // カスタマイズの比較（簡易比較）
+    const customizeChanged = !deepEqual(schema1.customize, schema2.customize);
+    const settingsChanged = !deepEqual(schema1.settings, schema2.settings);
+    const aclChanged = !deepEqual(schema1.acl, schema2.acl);
+    
+    const settingsChanges = (customizeChanged ? 1 : 0) + 
+                           (settingsChanged ? 1 : 0) + 
+                           (aclChanged ? 1 : 0);
+    
+    if (customizeChanged) {
+      differences.push({
+        path: 'customize',
+        oldValue: schema1.customize,
+        newValue: schema2.customize,
+        changeType: 'modified'
+      });
+    }
+    
+    if (settingsChanged) {
+      differences.push({
+        path: 'settings',
+        oldValue: schema1.settings,
+        newValue: schema2.settings,
+        changeType: 'modified'
+      });
+    }
+    
+    if (aclChanged) {
+      differences.push({
+        path: 'acl',
+        oldValue: schema1.acl,
+        newValue: schema2.acl,
+        changeType: 'modified'
+      });
+    }
+    
+    return {
+      appId1: schema1.appId,
+      appId2: schema2.appId,
+      comparedAt: new Date().toISOString(),
+      differences,
+      stats: {
+        fieldsAdded,
+        fieldsRemoved,
+        fieldsModified,
+        layoutChanges,
+        viewChanges,
+        settingsChanges,
+        totalChanges: differences.length
+      }
+    };
+  }
+  
+  /**
+   * キャッシュをクリアする
+   */
+  clearCache(): void {
+    this.cache.clear();
+  }
+  
+  /**
+   * キャッシュの有効/無効を設定する
+   * @param enabled 有効にする場合はtrue
+   */
+  setCacheEnabled(enabled: boolean): void {
+    this.cache.setEnabled(enabled);
   }
 }

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,6 +1,5 @@
 /**
- * サービスのエクスポート
+ * サービスモジュールのエクスポート
  */
-
 export * from './app-service';
 export * from './version-service';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,6 +11,17 @@ export interface AppInfo {
   description: string;
   spaceId?: string;
   threadId?: string;
+  // 拡張情報
+  creator?: {
+    code: string;
+    name: string;
+  };
+  createdAt?: string;
+  modifier?: {
+    code: string;
+    name: string;
+  };
+  modifiedAt?: string;
 }
 
 /**
@@ -61,6 +72,7 @@ export interface LayoutField {
  */
 export interface AppLayout {
   layout: LayoutElement[];
+  revision?: string;
 }
 
 /**
@@ -82,6 +94,73 @@ export interface AppViews {
   views: {
     [viewId: string]: AppView;
   };
+  revision?: string;
+}
+
+/**
+ * アプリカスタマイズ情報
+ */
+export interface AppCustomize {
+  desktop?: {
+    js?: Array<{
+      type: string;
+      url: string;
+    }>;
+    css?: Array<{
+      type: string;
+      url: string;
+    }>;
+  };
+  mobile?: {
+    js?: Array<{
+      type: string;
+      url: string;
+    }>;
+    css?: Array<{
+      type: string;
+      url: string;
+    }>;
+  };
+  revision?: string;
+}
+
+/**
+ * アプリアクセス権情報
+ */
+export interface AppAcl {
+  rights: Array<{
+    entity: {
+      type: 'USER' | 'GROUP' | 'ORGANIZATION' | 'FIELD_ENTITY';
+      code: string;
+    };
+    appEditable: boolean;
+    recordViewable: boolean;
+    recordAddable: boolean;
+    recordEditable: boolean;
+    recordDeletable: boolean;
+    recordImportable: boolean;
+    recordExportable: boolean;
+  }>;
+  revision?: string;
+}
+
+/**
+ * アプリ設定情報
+ */
+export interface AppSettings {
+  name?: string;
+  description?: string;
+  icon?: {
+    type: 'FILE' | 'PRESET';
+    key?: string;
+    file?: {
+      fileKey: string;
+    };
+  };
+  theme?: string;
+  revision?: string;
+  // その他の設定情報
+  [key: string]: any;
 }
 
 /**
@@ -92,6 +171,63 @@ export interface AppDetail {
   fields: AppFields;
   layout: AppLayout;
   views: AppViews;
+  // 拡張情報
+  customize?: AppCustomize;
+  acl?: AppAcl;
+  settings?: AppSettings;
+}
+
+/**
+ * アプリスキーマ
+ */
+export interface AppSchema {
+  appId: string;
+  name: string;
+  fields: AppFields;
+  layout: AppLayout;
+  views: AppViews;
+  customize?: AppCustomize;
+  acl?: AppAcl;
+  settings?: AppSettings;
+  // エクスポートメタデータ
+  exportedAt: string;
+  exportedBy: {
+    code: string;
+    name: string;
+  };
+}
+
+/**
+ * アプリ検索条件
+ */
+export interface AppSearchCriteria {
+  name?: string;
+  spaceIds?: string[];
+  limit?: number;
+  offset?: number;
+  creator?: string;
+  modifiedAfter?: string;
+  modifiedBefore?: string;
+}
+
+/**
+ * スキーマ比較結果
+ */
+export interface SchemaComparisonResult {
+  appId1: string;
+  appId2: string;
+  comparedAt: string;
+  differences: VersionDiff[];
+  // 統計情報
+  stats: {
+    fieldsAdded: number;
+    fieldsRemoved: number;
+    fieldsModified: number;
+    layoutChanges: number;
+    viewChanges: number;
+    settingsChanges: number;
+    totalChanges: number;
+  };
 }
 
 /**
@@ -116,6 +252,14 @@ export interface VersionDiff {
   oldValue: any;
   newValue: any;
   changeType: 'added' | 'removed' | 'modified';
+}
+
+/**
+ * キャッシュオプション
+ */
+export interface CacheOptions {
+  enabled: boolean;
+  ttl: number; // 有効期限（ミリ秒）
 }
 
 /**

--- a/src/utils/cache.test.ts
+++ b/src/utils/cache.test.ts
@@ -1,0 +1,149 @@
+/**
+ * キャッシュユーティリティのテスト
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { MemoryCache } from './cache';
+
+describe('MemoryCache', () => {
+  let cache: MemoryCache<any>;
+
+  beforeEach(() => {
+    // 各テスト前にキャッシュをリセット
+    cache = new MemoryCache();
+  });
+
+  afterEach(() => {
+    // モックをリセット
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('set と get でキャッシュの設定と取得ができること', () => {
+    cache.set('test-key', { data: 'test-data' });
+    expect(cache.get('test-key')).toEqual({ data: 'test-data' });
+  });
+
+  it('存在しないキーの get は null を返すこと', () => {
+    expect(cache.get('non-existent')).toBeNull();
+  });
+
+  it('delete でキャッシュを削除できること', () => {
+    cache.set('test-key', { data: 'test-data' });
+    expect(cache.get('test-key')).not.toBeNull();
+    
+    cache.delete('test-key');
+    expect(cache.get('test-key')).toBeNull();
+  });
+
+  it('clear ですべてのキャッシュをクリアできること', () => {
+    cache.set('key1', 'value1');
+    cache.set('key2', 'value2');
+    
+    expect(cache.size).toBe(2);
+    
+    cache.clear();
+    expect(cache.size).toBe(0);
+    expect(cache.get('key1')).toBeNull();
+    expect(cache.get('key2')).toBeNull();
+  });
+
+  it('TTLを過ぎると自動的にキャッシュが無効になること', () => {
+    // 時間をモック
+    vi.useFakeTimers();
+    
+    // TTLを100ミリ秒に設定
+    cache = new MemoryCache({ ttl: 100 });
+    cache.set('test-key', 'test-value');
+    
+    // TTL内ではキャッシュが有効
+    expect(cache.get('test-key')).toBe('test-value');
+    
+    // 101ミリ秒進める
+    vi.advanceTimersByTime(101);
+    
+    // TTL超過でキャッシュが無効になる
+    expect(cache.get('test-key')).toBeNull();
+  });
+
+  it('個別のTTLを指定できること', () => {
+    vi.useFakeTimers();
+    
+    // デフォルトTTLを100ミリ秒に設定
+    cache = new MemoryCache({ ttl: 100 });
+    
+    // キー1: デフォルトTTL(100ms)
+    cache.set('key1', 'value1');
+    
+    // キー2: カスタムTTL(300ms)
+    cache.set('key2', 'value2', 300);
+    
+    // 150ミリ秒進める
+    vi.advanceTimersByTime(150);
+    
+    // キー1はTTL超過で無効になるが、キー2は有効
+    expect(cache.get('key1')).toBeNull();
+    expect(cache.get('key2')).toBe('value2');
+    
+    // さらに200ミリ秒進める
+    vi.advanceTimersByTime(200);
+    
+    // キー2もTTL超過で無効になる
+    expect(cache.get('key2')).toBeNull();
+  });
+
+  it('cache.enabled=false でキャッシュが無効になること', () => {
+    // 有効状態
+    cache.set('test-key', 'test-value');
+    expect(cache.get('test-key')).toBe('test-value');
+    
+    // 無効化
+    cache.setEnabled(false);
+    
+    // 既存のキャッシュはクリアされる
+    expect(cache.get('test-key')).toBeNull();
+    
+    // 新しい値は保存されない
+    cache.set('new-key', 'new-value');
+    expect(cache.get('new-key')).toBeNull();
+    
+    // 再度有効化
+    cache.setEnabled(true);
+    
+    // 新しい値が保存される
+    cache.set('enabled-key', 'enabled-value');
+    expect(cache.get('enabled-key')).toBe('enabled-value');
+  });
+
+  it('cleanExpired で期限切れのキャッシュだけを削除できること', () => {
+    vi.useFakeTimers();
+    
+    cache = new MemoryCache({ ttl: 100 });
+    
+    // key1は短いTTL
+    cache.set('key1', 'value1', 50);
+    
+    // key2は長いTTL
+    cache.set('key2', 'value2', 200);
+    
+    // 70ミリ秒進める
+    vi.advanceTimersByTime(70);
+    
+    // cleanExpiredを呼び出す前はkey1はまだキャッシュに残っている
+    expect(cache.size).toBe(2);
+    
+    // 期限切れのkey1だけをクリア
+    cache.cleanExpired();
+    
+    // key1は削除され、key2は残る
+    expect(cache.size).toBe(1);
+    expect(cache.get('key1')).toBeNull();
+    expect(cache.get('key2')).toBe('value2');
+    
+    // さらに時間を進めてkey2も期限切れに
+    vi.advanceTimersByTime(150);
+    cache.cleanExpired();
+    
+    // すべてのキーが削除される
+    expect(cache.size).toBe(0);
+  });
+});

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,0 +1,131 @@
+/**
+ * キャッシュユーティリティ
+ * メモリキャッシュの実装
+ */
+
+import { CacheOptions } from '../types';
+
+/**
+ * キャッシュアイテム
+ */
+interface CacheItem<T> {
+  value: T;
+  expires: number; // 有効期限のタイムスタンプ
+}
+
+/**
+ * メモリキャッシュクラス
+ */
+export class MemoryCache<T> {
+  private cache: Map<string, CacheItem<T>>;
+  private options: CacheOptions;
+
+  /**
+   * コンストラクタ
+   * @param options キャッシュオプション
+   */
+  constructor(options: Partial<CacheOptions> = {}) {
+    this.cache = new Map<string, CacheItem<T>>();
+    this.options = {
+      enabled: options.enabled !== undefined ? options.enabled : true,
+      ttl: options.ttl || 5 * 60 * 1000, // デフォルト5分
+    };
+  }
+
+  /**
+   * キャッシュに値を設定する
+   * @param key キャッシュキー
+   * @param value 値
+   * @param ttl 有効期限（ミリ秒）、指定しない場合はデフォルト値
+   */
+  set(key: string, value: T, ttl?: number): void {
+    if (!this.options.enabled) return;
+
+    const actualTtl = ttl || this.options.ttl;
+    const expires = Date.now() + actualTtl;
+    
+    this.cache.set(key, { value, expires });
+  }
+
+  /**
+   * キャッシュから値を取得する
+   * @param key キャッシュキー
+   * @returns キャッシュに値がある場合はその値、ない場合はnull
+   */
+  get(key: string): T | null {
+    if (!this.options.enabled) return null;
+
+    const item = this.cache.get(key);
+    
+    // キャッシュが存在しない場合
+    if (!item) return null;
+    
+    // 有効期限切れの場合
+    if (Date.now() > item.expires) {
+      this.cache.delete(key);
+      return null;
+    }
+    
+    return item.value;
+  }
+
+  /**
+   * キャッシュを削除する
+   * @param key キャッシュキー
+   */
+  delete(key: string): void {
+    this.cache.delete(key);
+  }
+
+  /**
+   * キャッシュをすべて削除する
+   */
+  clear(): void {
+    this.cache.clear();
+  }
+
+  /**
+   * キャッシュアイテムの数を取得する
+   */
+  get size(): number {
+    return this.cache.size;
+  }
+
+  /**
+   * 有効期限切れのキャッシュを削除する
+   */
+  cleanExpired(): void {
+    if (!this.options.enabled) return;
+
+    const now = Date.now();
+    for (const [key, item] of this.cache.entries()) {
+      if (now > item.expires) {
+        this.cache.delete(key);
+      }
+    }
+  }
+
+  /**
+   * キャッシュの有効／無効を設定する
+   * @param enabled 有効にする場合はtrue
+   */
+  setEnabled(enabled: boolean): void {
+    this.options.enabled = enabled;
+    
+    // 無効化される場合は全てのキャッシュをクリア
+    if (!enabled) {
+      this.clear();
+    }
+  }
+
+  /**
+   * デフォルトのTTLを設定する
+   * @param ttl 有効期限（ミリ秒）
+   */
+  setDefaultTtl(ttl: number): void {
+    this.options.ttl = ttl;
+  }
+}
+
+// シングルトンインスタンス
+export const appCache = new MemoryCache();


### PR DESCRIPTION
## 概要
kintoneアプリの情報を取得するサービスを実装しました。このサービスはAPI通信クライアントを使用して、kintoneアプリの設定情報を取得します。

## 主な変更点
1. **型定義の拡充**
   - アプリ情報関連の型定義を拡張（`AppCustomize`、`AppAcl`、`AppSettings`など）
   - アプリスキーマ関連の型定義を追加（`AppSchema`、`SchemaComparisonResult`）
   - キャッシュ機能の型定義を追加（`CacheOptions`）

2. **キャッシュ機能実装**
   - メモリキャッシュクラス（`MemoryCache`）の実装
   - TTL（有効期限）付きのキャッシュ機能
   - キャッシュの有効化・無効化切り替え機能

3. **アプリ情報取得サービスの機能拡充**
   - インターフェース定義（`IAppService`）
   - 基本APIメソッドの実装
     - `getAllApps`: すべてのアプリ情報取得
     - `getAppDetails`: アプリの詳細情報取得
     - `getAppFormFields`: フォームフィールド情報取得
     - `getAppFormLayout`: フォームレイアウト情報取得
     - `getAppViews`: ビュー情報取得
   - 追加機能の実装
     - `getAppCustomize`: アプリのカスタマイズ情報取得
     - `searchApps`: 条件に基づくアプリの検索
     - `exportAppSchema`: アプリスキーマのエクスポート
     - `compareAppSchemas`: 2つのアプリスキーマの比較
   - キャッシュ機能の統合

4. **テストの拡充**
   - キャッシュ機能のテスト
   - アプリ情報取得サービスの全メソッドのテスト
   - 異常系も含めたテストカバレッジの向上

## 技術的詳細
- パフォーマンス向上のためキャッシュシステムを実装
- 各APIアクセスにはキャッシュを適用、重複リクエストを防止
- スキーマ比較機能では `deep-equal` パッケージを使用
- アクセス権・設定情報取得メソッドは将来的な拡張を見据えたインターフェース定義のみ実装

## 動作確認
- 既存テストが正常に動作することを確認
- 新規追加した機能のテストを実装済み
- キャッシュ機能の有効性を確認

## 関連Issue
本PRはIssue #5 を実装しています。

## 備考
- `getAppAcl`と`getAppSettings`メソッドは現状ではモック実装になっており、今後のAPIクライアント拡張時に正式実装される予定です。
- スキーマ比較機能はJSON構造の差分検出を行いますが、個別フィールドの詳細な差分検出は今後の課題です。